### PR TITLE
Add RRadio component for radio input functionality

### DIFF
--- a/src/components/Radio/RRadio.vue
+++ b/src/components/Radio/RRadio.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import './radio.css'
+import { computed, defineProps, ref, watch } from 'vue'
+
+export interface Props {
+  id: string
+  modelValue?: string | number | boolean
+  name?: string
+  disabled?: boolean
+  label?: string
+  hint?: string
+  errorMsg?: string
+  title?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  id: 'radio-id',
+  modelValue: false,
+  name: 'radio-group',
+  disabled: false,
+  label: '',
+  hint: '',
+  errorMsg: '',
+  title: '',
+})
+
+// Emits 'update:modelValue' event when the value changes
+defineEmits(['update:modelValue'])
+
+const checked = ref(props.modelValue)
+
+// Classes to control the radio's styling
+const classes = computed(() => [
+  'r-radio group',
+  {
+    'r-radio--disabled': props.disabled,
+    'r-radio--error': props.errorMsg,
+  },
+])
+
+// Watch for changes in modelValue and update the checked ref
+watch(() => props.modelValue, (newVal) => {
+  checked.value = newVal
+})
+</script>
+
+<template>
+  <div :class="classes">
+    <input
+      v-bind="$attrs"
+      :id="props.id"
+      :checked="checked"
+      class="r-radio__input"
+      :disabled="props.disabled"
+      :name="props.name"
+      type="radio"
+      @input="$emit('update:modelValue', !checked)"
+    >
+
+    <label class="r-radio__label" :class="[props.errorMsg && 'r-radio__label--error']" :for="props.id">
+      <span
+        class="r-radio__custom"
+        :class="[props.errorMsg && 'r-radio__custom--error', props.disabled && 'r-radio__custom--disabled']"
+      />
+      <div class="flex flex-col">
+        <span
+          v-if="props.title"
+          class="r-radio__title"
+          :class="[props.errorMsg && 'r-radio__title--error', props.disabled && 'r-radio__title--disabled']"
+        >
+          {{ props.title }}
+        </span>
+        <span>
+          {{ props.label }}
+        </span>
+      </div>
+    </label>
+    <span
+      v-if="props.hint && !props.errorMsg"
+      class="r-radio__hint"
+      :class="[props.disabled && 'r-radio__hint--disabled']"
+    >{{ props.hint }}</span>
+
+    <!-- Display error message if it exists -->
+    <span v-if="props.errorMsg" class="r-radio__error">{{ props.errorMsg }}</span>
+  </div>
+</template>

--- a/src/components/Radio/RRadio.vue
+++ b/src/components/Radio/RRadio.vue
@@ -4,7 +4,7 @@ import { computed, defineProps, ref, watch } from 'vue'
 
 export interface Props {
   id: string
-  modelValue?: string | number | boolean
+  modelValue?: boolean
   name?: string
   disabled?: boolean
   label?: string

--- a/src/components/Radio/Radio.stories.ts
+++ b/src/components/Radio/Radio.stories.ts
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import Radio from './RRadio.vue'
+
+const DefaultArgs = {
+  id: 'radio',
+  modelValue: false,
+  name: 'radio-group',
+  disabled: false,
+  label: 'Save my login details for next time.',
+  hint: 'A control used to switch between two states: often on or off.',
+  errorMsg: '',
+  title: 'Radio Title',
+}
+
+const RadioStory = {
+  title: 'Form/Radio',
+  component: Radio,
+  setup: (args: typeof Radio) => ({
+    args,
+  }),
+  template: '<Radio v-bind="args" />',
+  args: DefaultArgs,
+  argTypes: {
+  },
+  tags: ['autodocs'],
+} as Meta<typeof Radio>
+
+export default RadioStory
+
+type Story = StoryObj<typeof RadioStory>
+
+export const Overview: Story = {}
+
+export const Checked: Story = {
+  args: {
+    modelValue: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+export const Error: Story = {
+  args: {
+    errorMsg: 'This is an error message',
+  },
+}

--- a/src/components/Radio/radio.css
+++ b/src/components/Radio/radio.css
@@ -1,0 +1,87 @@
+/* General Radio container styling */
+.r-radio {
+  @apply flex flex-col cursor-pointer mb-4;
+}
+
+/* Hide the default radio input */
+.r-radio__input {
+  @apply sr-only;
+}
+
+/* Custom Radio Circle */
+.r-radio__custom {
+  @apply w-5 h-5 border border-[var(--primary-500)] rounded-full mr-2.5 inline-block relative flex-shrink-0 transition-all duration-300 ease-in-out;
+}
+
+/* Add the inner dot when checked */
+.r-radio__input:checked + .r-radio__label .r-radio__custom::before {
+  @apply content-[''] block w-2 h-2 bg-[var(--white)] rounded-full absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2;
+}
+
+.r-radio__input:checked + .r-radio__label .r-radio__custom {
+  @apply bg-[var(--primary-500)] border-[var(--primary-500)];
+}
+
+/* Style the label */
+.r-radio__label {
+  @apply flex items-center cursor-pointer text-xs font-medium text-[var(--neutral-900)] select-none;
+}
+
+/* Disabled state */
+.r-radio--disabled .r-radio__label {
+  @apply text-[var(--neutral-300)] cursor-not-allowed;
+}
+
+.r-radio--disabled .r-radio__custom {
+  @apply border-[var(--neutral-300)];
+}
+
+.r-radio__input:disabled + .r-radio__label .r-radio__custom::before {
+  @apply bg-[var(--neutral-300)];
+}
+
+/* Hint styling */
+.r-radio__hint {
+  @apply text-xs font-normal text-[var(--neutral-500)] mt-1 ml-8;
+}
+
+.r-radio__hint--disabled {
+  @apply text-[var(--neutral-300)] cursor-not-allowed;
+}
+
+/* Error state */
+.r-radio--error .r-radio__custom {
+  @apply border-[var(--error-500)];
+}
+
+.r-radio--error .r-radio__label {
+  @apply text-[var(--error-500)];
+}
+
+.r-radio__error {
+  @apply ml-8 text-xs font-normal text-[var(--error-500)];
+}
+
+.r-radio__input:checked + .r-radio__label--error .r-radio__custom--error {
+  @apply bg-[var(--error-500)] border-[var(--error-500)];
+}
+
+.r-radio__custom--error:hover {
+  @apply shadow-[0px_0px_0px_4px_var(--error-50)];
+}
+
+.r-radio__custom:hover:not(.r-radio__custom--disabled) {
+  @apply shadow-[0px_0px_0px_4px_var(--primary-50)];
+}
+
+.r-radio__title {
+  @apply text-sm font-medium text-[var(--neutral-900)];
+}
+
+.r-radio__title--disabled {
+  @apply text-[var(--neutral-300)] cursor-not-allowed;
+}
+
+.r-radio__title--error {
+  @apply text-[var(--error-500)];
+}


### PR DESCRIPTION
This pull request adds a new component called RRadio, which provides radio input functionality. The component accepts props such as id, modelValue, name, disabled, label, hint, errorMsg, and title. It emits an 'update:modelValue' event when the value changes. The component also includes CSS styling for the radio input and its label, with support for disabled and error states.